### PR TITLE
Add .hip extension.

### DIFF
--- a/git-clang-format.py
+++ b/git-clang-format.py
@@ -81,6 +81,7 @@ def main():
       'mm',  # ObjC++
       'cc', 'cp', 'cpp', 'c++', 'cxx', 'hh', 'hpp', 'hxx', 'inc', 'inl',  # C++
       'cu',  # CUDA
+      'hip',  # HIP
       # Other languages that clang-format supports
       'proto', 'protodevel',  # Protocol Buffers
       'java',  # Java


### PR DESCRIPTION
Add .hip as possible clang-format extension for the HIP language dialect.